### PR TITLE
updating socket open to allow for port number change (collectd.conf)

### DIFF
--- a/org/collectd/java/OpenTSDB.java
+++ b/org/collectd/java/OpenTSDB.java
@@ -40,7 +40,7 @@ public class OpenTSDB implements CollectdWriteInterface,
     {
         try {
           Collectd.logInfo ("OpenTSDB plugin: server: " + server + ", port: " + port);
-          socket = new Socket (server, 4242);
+          socket = new Socket (server, port);
           _out   = new PrintStream(socket.getOutputStream());
         } catch (UnknownHostException e) {
           Collectd.logError ("Couldn't establish connection: " + e.getMessage());


### PR DESCRIPTION
If the user specifies a new server/port combination in the collectd.conf entry, we should use that port number when creating a socket.

This defaults to 4242 earlier in the script so if nothing is passed, the localhost:4242 entry is preserved.
